### PR TITLE
Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "x3m/germanphonetic",
+    "description": "Cologne phonetics implementations in PHP and SQL",
+    "type": "library",
+    "license": "BSD-2-Clause",
+    "authors": [
+        {
+            "name": "deezaster",
+            "email": "andy.theiler@x3m.ch"
+        }
+    ],
+    "minimum-stability": "stable",
+    "require": {}
+}


### PR DESCRIPTION
This pull request is important to allow us to standardize where `germanphonetic` is placed: in the vendor directory of the dependent project.