### PR TITLE
Umlaute richtig behandeln

### DIFF
--- a/x3m_soundex_ger.php
+++ b/x3m_soundex_ger.php
@@ -71,7 +71,7 @@ function soundex_ger($word)
    //echo "<br>input: <b>" . $word . "</b>";
 
    $code = "";
-   $word = strtolower($word);
+   $word = mb_strtolower($word);
 
    if (strlen($word) < 1) {
       return "";


### PR DESCRIPTION
Ö wurde nicht richtig zu o umgewandelt