### PR TITLE
Fix undefined array keys in php 8.4

### DIFF
--- a/x3m_soundex_ger.php
+++ b/x3m_soundex_ger.php
@@ -87,7 +87,7 @@ function soundex_ger($word)
 
 
    $wordlen = strlen($word);
-   $char = str_split($word);
+   $char = str_split($word) ?: [''];
 
 
    // Sonderfälle bei Wortanfang (Anlaut)
@@ -228,7 +228,7 @@ function soundex_ger($word)
    // entfernen aller Codes "0" ausser am Anfang
    $codelen = strlen($code);
    $num = array();
-   $num = str_split($code);
+   $num = str_split($code) ?: [''];
    $phoneticcode = $num[0];
 
    for ($x = 1; $x < $codelen; $x++) {
@@ -241,3 +241,4 @@ function soundex_ger($word)
 }
 
 ?>
+


### PR DESCRIPTION
In php 8.4 str_split('') returns [] instead of [''], which causes undefined key warnings.